### PR TITLE
Check if core/latest-comments is registered before trying to unregister

### DIFF
--- a/src/disable-comments.js
+++ b/src/disable-comments.js
@@ -1,5 +1,6 @@
 wp.domReady(() => {
-	if(wp.blocks) {
-		wp.blocks.unregisterBlockType('core/latest-comments');
+	const blockType = 'core/latest-comments';
+	if(wp.blocks && wp.data && wp.data.select('core/blocks').getBlockType( blockType )) {
+		wp.blocks.unregisterBlockType(blockType);
 	}
 });


### PR DESCRIPTION
Check if `core/latest-comments` is registered before trying to unregister otherwise, there is [an error in the browser logs](https://github.com/WordPress/gutenberg/blob/97c26524ee699ff8674e901bbd8c1c771fee92ac/packages/blocks/src/api/registration.js#L375).


Reported in https://wordpress.org/support/topic/gutenberg-error-block-core-latest-comments-is-not-registered/